### PR TITLE
Add hybrid neighbor compressor

### DIFF
--- a/train.py
+++ b/train.py
@@ -132,6 +132,8 @@ retrieval_milvus_port = "19530" # Milvus port
 retrieval_milvus_collection_name = 'omnikb_64_gpt2_with_continuations'  # Milvus collection name
 retrieval_k_neighbors = 2  # Number of neighbors to retrieve
 retrieval_neighbor_size = 128 # Maximum sequence length for neighbor encoder
+retrieval_compressor_layers = 1 # Number of self-attention layers in neighbor compressor
+retrieval_compressed_size = 32 # Compressed length for neighbor encodings
 retrieval_neighbor_continuations = True # Whether to extend retrieved neighbors with next records
 # -----------------------------------------------------------------------------
 config_keys = [k for k,v in globals().items() if not k.startswith('_') and isinstance(v, (int, float, bool, str))]
@@ -323,6 +325,8 @@ model_args = dict(
     retrieval_milvus_collection_name=retrieval_milvus_collection_name,
     retrieval_k_neighbors=retrieval_k_neighbors,
     retrieval_neighbor_size=retrieval_neighbor_size,
+    retrieval_compressor_layers=retrieval_compressor_layers,
+    retrieval_compressed_size=retrieval_compressed_size,
     retrieval_neighbor_continuations=retrieval_neighbor_continuations,
 ) # start with model_args from command line
 gptconf = GPTConfig(**model_args)
@@ -363,6 +367,8 @@ elif init_from.startswith('gpt2'):
         retrieval_milvus_collection_name=retrieval_milvus_collection_name,
         retrieval_k_neighbors=retrieval_k_neighbors,
         retrieval_neighbor_size=retrieval_neighbor_size,
+        retrieval_compressor_layers=retrieval_compressor_layers,
+        retrieval_compressed_size=retrieval_compressed_size,
         retrieval_neighbor_continuations=retrieval_neighbor_continuations,
     )
     model = GPT.from_pretrained(init_from, override_args)


### PR DESCRIPTION
## Summary
- compress neighbor tokens with a small Transformer followed by learnable query attention
- add `retrieval_compressor_layers` option and wire through training config

## Testing
- `python -m py_compile model.py train.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68a31ded92dc832ba6b8612a61033e4b